### PR TITLE
fix: footer year text align left and right

### DIFF
--- a/app/cfp/_components/footer.tsx
+++ b/app/cfp/_components/footer.tsx
@@ -200,10 +200,16 @@ function FooterSubMenuGrid({
         {links.map((link) => {
           const { text, href } = link;
           return (
-            <li key={href}>
-              <Link target="_blank" className="hover:opacity-70" href={href}>
-                {text}
-              </Link>
+            <li key={href} className="text-center">
+              <a target="_blank" className="inline-block hover:opacity-70" href={href}>
+                <span className="inline-block">
+                  {text.split("").map((char, index) => (
+                    <span key={index} className="inline-block w-2.5 text-center">
+                      {char}
+                    </span>
+                  ))}
+                </span>
+              </a>
             </li>
           );
         })}


### PR DESCRIPTION
This PR adjusts the footer to ensure the year text aligns both left and right. Please feel free to review and merge it if needed, or close it if it's not applicable. :D