### PR TITLE
fix: agenda table error when client is non-UTC+8

### DIFF
--- a/app/(website)/_utils/time-render.ts
+++ b/app/(website)/_utils/time-render.ts
@@ -1,9 +1,10 @@
 const timeRender = (datetime: string) => {
   const time = new Date(datetime);
-  return time.toLocaleTimeString("zh-TW", {
+  return time.toLocaleTimeString("en-US", {
     hour: "numeric",
     minute: "2-digit",
     hour12: false,
+    timeZone: "Asia/Taipei",
   });
 };
 


### PR DESCRIPTION
If the client does not set the timezone to UTC+8, it will cause errors in the table calculations in the agenda.
Bug sample:
![image](https://github.com/user-attachments/assets/3f3e9a10-5a94-41ec-9b91-af5c2aef25fe)